### PR TITLE
Fix data export (#33)

### DIFF
--- a/src/components/account/ExportButton.jsx
+++ b/src/components/account/ExportButton.jsx
@@ -21,7 +21,9 @@ export default function ExportButton() {
       const blob = await response.blob();
       const blobUrl = URL.createObjectURL(blob);
       setExportUrl(blobUrl);
-      dlButton.current.click();
+      setTimeout(() => {
+        dlButton.current.click();
+      });
       toast.success('You can download your data now!');
     } else {
       toast.error('An error occured, please try again later.');


### PR DESCRIPTION
This just defers the download to the next event cycle, allowing React enough time to properly update the href.