### PR TITLE
Custom RiiTag backgrounds

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,28 +57,29 @@ model sys {
 }
 
 model user {
-  id             Int       @id @default(autoincrement())
-  username       String    @unique @db.VarChar(50)
-  role           String    @default("user") @db.VarChar(25)
-  name_on_riitag String?   @db.VarChar(255)
-  image          String?   @db.VarChar(255)
-  randkey        String?   @unique @db.VarChar(200)
-  coins          Int       @default(0) @db.UnsignedInt
-  cover_region   String    @default("EN") @db.VarChar(6)
-  cover_type     String    @default("cover3D") @db.VarChar(10)
-  comment        String?   @db.VarChar(50)
-  overlay        String    @default("overlay1") @db.VarChar(20)
-  background     String    @default("riiconnect241.png") @db.VarChar(120)
-  flag           String    @default("rc24") @db.VarChar(20)
-  coin           String    @default("mario") @db.VarChar(20)
-  font           String    @default("default") @db.VarChar(50)
-  show_avatar    Boolean   @default(false)
-  show_mii       Boolean   @default(false)
-  mii_type       String    @default("guest") @db.VarChar(10)
-  mii_data       String?   @db.VarChar(8192)
-  cmoc_entry_no  String?   @db.VarChar(12)
-  created_at     DateTime  @default(now())
-  updated_at     DateTime  @default(now()) @updatedAt
-  accounts       account[]
-  playlog        playlog[]
+  id                Int       @id @default(autoincrement())
+  username          String    @unique @db.VarChar(50)
+  role              String    @default("user") @db.VarChar(25)
+  name_on_riitag    String?   @db.VarChar(255)
+  image             String?   @db.VarChar(255)
+  randkey           String?   @unique @db.VarChar(200)
+  coins             Int       @default(0) @db.UnsignedInt
+  cover_region      String    @default("EN") @db.VarChar(6)
+  cover_type        String    @default("cover3D") @db.VarChar(10)
+  comment           String?   @db.VarChar(50)
+  overlay           String    @default("overlay1") @db.VarChar(20)
+  background_custom Boolean   @default(false)
+  background        String    @default("riiconnect241.png") @db.VarChar(120)
+  flag              String    @default("rc24") @db.VarChar(20)
+  coin              String    @default("mario") @db.VarChar(20)
+  font              String    @default("default") @db.VarChar(50)
+  show_avatar       Boolean   @default(false)
+  show_mii          Boolean   @default(false)
+  mii_type          String    @default("guest") @db.VarChar(10)
+  mii_data          String?   @db.VarChar(8192)
+  cmoc_entry_no     String?   @db.VarChar(12)
+  created_at        DateTime  @default(now())
+  updated_at        DateTime  @default(now()) @updatedAt
+  accounts          account[]
+  playlog           playlog[]
 }

--- a/src/lib/constants/filePaths.js
+++ b/src/lib/constants/filePaths.js
@@ -13,6 +13,7 @@ export const CACHE = Object.freeze({
   MIIS: path.resolve(CACHE_PATH, 'mii', 'user'),
   TAGS: path.resolve(CACHE_PATH, 'tags'),
   WADS: path.resolve(CACHE_PATH, 'wads'),
+  BACKGROUNDS: path.resolve(CACHE_PATH, 'user_backgrounds')
 });
 
 export const PUBLIC = Object.freeze({

--- a/src/lib/riitag/banner.js
+++ b/src/lib/riitag/banner.js
@@ -110,7 +110,7 @@ export async function makeBanner(user) {
   const context = canvas.getContext('2d');
 
   // Background image
-  const bgPath = path.resolve(PUBLIC.BACKGROUND, user.background);
+  const bgPath = path.resolve(user.background_custom ? CACHE.BACKGROUNDS : PUBLIC.BACKGROUND, user.background);  
   if (!(await exists(bgPath))) {
     throw new Error(`Background ${user.background} does not exist`);
   }

--- a/src/pages/api/account/background-upload.js
+++ b/src/pages/api/account/background-upload.js
@@ -1,0 +1,100 @@
+import { IncomingForm } from 'formidable';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { ncWithSession } from '@/lib/routing';
+import HTTP_CODE from '@/lib/constants/httpStatusCodes';
+import { saveFile } from '@/lib/utils/fileUtils';
+import { CACHE } from '@/lib/constants/filePaths';
+import prisma from '@/lib/db';
+import { makeBanner } from '@/lib/riitag/banner';
+import logger from '@/lib/logger';
+
+async function uploadBackground(request, response) {
+  if (request.socket.bytesRead > 2_107_638) {
+    return response
+      .status(HTTP_CODE.REQUEST_ENTITY_TOO_LARGE)
+      .send({ error: 'Request entity too large.' });
+  }
+  const username = request.session?.username;
+
+  if (!username) {
+    return response
+      .status(HTTP_CODE.UNAUTHORIZED)
+      .json({ error: 'Unauthorized' });
+  }
+
+  const data = await new Promise((resolve, reject) => {
+    const form = new IncomingForm();
+
+    form.parse(request, (error, fields, files) => {
+      if (error) {
+        return reject(error);
+      }
+      return resolve({ fields, files });
+    });
+  }).catch((error) => {
+    logger.error(error);
+    return response
+      .status(HTTP_CODE.BAD_REQUEST)
+      .send({ error: 'Invalid data' });
+  });
+
+  const { file } = data.files;
+
+  if (file.mimetype !== 'image/png') {
+    return response
+      .status(HTTP_CODE.BAD_REQUEST)
+      .send({ error: 'Invalid data' });
+  }
+
+  // Hard cap of 2MBs for custom backgrounds
+  if (file.size > 2_000_000) {
+    return response
+      .status(HTTP_CODE.REQUEST_ENTITY_TOO_LARGE)
+      .send({ error: 'Request entity too large.' });
+  }
+
+  let user = await prisma.user.findFirst({
+    where: {
+      username,
+    },
+    select: {
+      username: true,
+    },
+  });
+
+  const filepath = path.resolve(CACHE.BACKGROUNDS, `${user.username}.png`);
+
+  try {
+    await saveFile(filepath, await readFile(file.filepath));
+
+    user = await prisma.user.update({
+      where: {
+        username,
+      },
+      data: {
+        background_custom: true,
+        background: `${user.username}.png`,
+      },
+    });
+  } catch (error) {
+    logger.error(error);
+    return response
+      .status(HTTP_CODE.BAD_REQUEST)
+      .send({ error: 'Invalid data' });
+  }
+
+  makeBanner(user);
+
+  return response.status(HTTP_CODE.OK).send();
+}
+
+const handler = ncWithSession().post(uploadBackground);
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+export default handler;


### PR DESCRIPTION
This PR will hopefully close #12 , as of the first commit the backend logic is based from mii-upload.js, and has not been tested. What's left to do is to:
- Figure out a way to display the custom background preview on the RiiTag panel
- Make a button in the backgrounds tab to upload a custom background that then calls the uploadBackground function of the newly created background-upload.js
- Somehow come up with a way to let others use someone else's backgrounds
- Delete unused custom backgrounds after a while for storage precautions
- Come up with a moderation system for the backgrounds to require manual approval by RiiConnect24 staff
- Sanitize the image uploads to avoid potential threat actors from exploiting the upload system
- Automatically make user images compatible (images must be 1200x450, be under 2MBs, not have already been uploaded, etcetera)
This _will_ take a while to fully complete, and I lack any experience with jsx or the frontend part of RiiTag. Suggestions, observations, or additions are more than welcome.