### PR TITLE
Make Discord the only account type

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ You can set yourself as an administrator by chaing the "role" column to "admin" 
 | DATABASE_URL              | Connection String                                               | mysql://USER:PASSWORD@127.0.0.1:3306/DATABASE  |
 | IRON_SECRET               | Secret for Iron to encrypt the cookie                           | stringwithatleast64chars                       |
 | DISCORD_CLIENT_ID         | Discord Client ID                                               |                                                |
-| DISCORD_CLIENT_SECRET     | Discord Client Secret                                           |                                                |
-| TWITTER_API_KEY           | Twitter API Key                                                 |                                                |
-| TWITTER_API_SECRET_KEY    | Twitter API Secret Key                                          |                                                |
+| DISCORD_CLIENT_SECRET     | Discord Client Secret                                            |                                                |
 | WEBPACK_ANALYZE           | Runs Webpack Analyzer on start                                  | true                                           |
 | NEXT_PUBLIC_LOGGING_LEVEL | Logging Level                                                   | TRACE, DEBUG, INFO, WARNING, ERROR or CRITICAL |
 | NEXT_PUBLIC_STAGING       | If the instance is a staging instance where data may be deleted | true                                           |

--- a/src/components/account/OAuthAccountsCard.jsx
+++ b/src/components/account/OAuthAccountsCard.jsx
@@ -10,31 +10,19 @@ function OAuthAccountsCard({ accounts }) {
   const getProvider = ({ created_at, provider_id }) => (
     <Row key={provider_id}>
       <Col>
-        {provider_id === 'discord' ? (
-          <>
-            <FontAwesomeIcon className="me-1" icon={faDiscord} />
-            <strong>Discord</strong>
-          </>
-        ) : (
-          <>
-            <FontAwesomeIcon className="me-1" icon={faQuestion} />
-            <strong>{provider_id} (Unsupported)</strong>
-          </>
-        )}{' '}
+        <>
+          <FontAwesomeIcon className="me-1" icon={faDiscord} />
+          <strong>Discord</strong>
+        </>
         - Linked on {dayjs(created_at).format(DATE_FORMAT)}
-        {accounts.length === 1 && (
-          <>
-            <br />
-            <i>You cannot unlink your only account.</i>
-          </>
-        )}
+        {accounts.length}
       </Col>
     </Row>
   );
 
   return (
     <Card className="mb-3" bg="secondary" text="white">
-      <Card.Header className="h5">Linked accounts</Card.Header>
+      <Card.Header className="h5">Linked Discord Account</Card.Header>
       <Card.Body>
         {accounts.map((account) => getProvider(account))}
         {/* <hr /> */}


### PR DESCRIPTION
We had originally planned on supporting platforms which had been more than Discord, but I think that the only one we're gonna support is Discord.